### PR TITLE
Link 16/actions/edit.svg to document-edit.svg

### DIFF
--- a/theme.conf
+++ b/theme.conf
@@ -677,7 +677,7 @@
 22/actions disconnect.svg gtk-disconnect.svg
 22/actions trash.svg gtk-delete.svg list-remove.svg edit-delete.svg
 22/actions trash_undelete.svg gtk-undelete.svg list-restore.svg edit-undelete.svg
-22/actions edit.svg gtk-edit.svg
+22/actions edit.svg gtk-edit.svg document-edit.svg
 22/actions execute.svg gtk-execute.svg system-run.svg
 22/actions execute_inspect.svg gtk-find-and-replace.svg edit-find-replace.svg
 22/actions find.svg gtk-find.svg edit-find.svg
@@ -1120,7 +1120,7 @@
 24/actions disconnect.svg gtk-disconnect.svg
 24/actions trash.svg gtk-delete.svg list-remove.svg edit-delete.svg
 24/actions trash_undelete.svg gtk-undelete.svg list-restore.svg edit-undelete.svg
-24/actions edit.svg gtk-edit.svg
+24/actions edit.svg gtk-edit.svg document-edit.svg
 24/actions execute.svg gtk-execute.svg system-run.svg
 24/actions execute_inspect.svg gtk-find-and-replace.svg edit-find-replace.svg
 24/actions find.svg gtk-find.svg edit-find.svg
@@ -1584,7 +1584,7 @@
 32/actions disconnect.svg gtk-disconnect.svg
 32/actions trash.svg gtk-delete.svg list-remove.svg edit-delete.svg
 32/actions trash_undelete.svg gtk-undelete.svg list-restore.svg edit-undelete.svg
-32/actions edit.svg gtk-edit.svg
+32/actions edit.svg gtk-edit.svg document-edit.svg
 32/actions execute.svg gtk-execute.svg system-run.svg
 32/actions execute_inspect.svg gtk-find-and-replace.svg edit-find-replace.svg
 32/actions find.svg gtk-find.svg edit-find.svg
@@ -2031,7 +2031,7 @@
 48/actions disconnect.svg gtk-disconnect.svg
 48/actions trash.svg gtk-delete.svg list-remove.svg edit-delete.svg
 48/actions trash_undelete.svg gtk-undelete.svg list-restore.svg edit-undelete.svg
-48/actions edit.svg gtk-edit.svg
+48/actions edit.svg gtk-edit.svg document-edit.svg
 48/actions execute.svg gtk-execute.svg system-run.svg
 48/actions execute_inspect.svg gtk-find-and-replace.svg edit-find-replace.svg
 48/actions find.svg gtk-find.svg edit-find.svg
@@ -2472,7 +2472,7 @@
 64/actions disconnect.svg gtk-disconnect.svg
 64/actions trash.svg gtk-delete.svg list-remove.svg edit-delete.svg
 64/actions trash_undelete.svg gtk-undelete.svg list-restore.svg edit-undelete.svg
-64/actions edit.svg gtk-edit.svg
+64/actions edit.svg gtk-edit.svg document-edit.svg
 64/actions execute.svg gtk-execute.svg system-run.svg
 64/actions execute_inspect.svg gtk-find-and-replace.svg edit-find-replace.svg
 64/actions find.svg gtk-find.svg edit-find.svg

--- a/theme.conf
+++ b/theme.conf
@@ -251,6 +251,7 @@
 16/actions harddisk.svg gtk-harddisk.svg drive-harddisk.svg
 16/actions indent-ltr.svg gtk-indent-ltr.svg format-indent-more.svg
 16/actions dialog-info.svg gtk-info.svg dialog-information.svg
+16/actions edit.svg document-edit.svg
 16/actions format-text-italic.svg gtk-italic.svg
 16/actions jump_to_left.svg gtk-jump-to.svg gtk-jump-to-ltr.svg go-jump.svg
 16/actions jump_to_right.svg gtk-jump-to-rtl.svg


### PR DESCRIPTION
This resolves one of the three missing icons at https://github.com/puppylinux-woof-CE/woof-CE/issues/3781.