### PR TITLE
Make volume icons brighter, with more contrast on dark background

### DIFF
--- a/icons/audio-volume-high.svg
+++ b/icons/audio-volume-high.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 192 192">
-  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#000;fill-opacity:0.5;stroke:#000;stroke-width:6;">
+  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#959595;stroke:#000;stroke-width:6;">
   	<path d="m 96,40 0,116 -50,-40 -20,0 0,-36 20,0 z"/>
   	<g transform="rotate(45,96,96)">
-  	  <path style="fill:none;" d="m 96,80 a 20,20 0 0 1 20,20 m -20,-40 a 40,40 0 0 1 40,40 m-40,-60 a 60,60 0 0 1 60,60"/>
+  	  <path style="fill:none;stroke:#007B00;stroke-width:12;" d="m 96,80 a 20,20 0 0 1 20,20 m -20,-40 a 40,40 0 0 1 40,40 m-40,-60 a 60,60 0 0 1 60,60"/>
   	</g>
   </g>
 </svg>

--- a/icons/audio-volume-low.svg
+++ b/icons/audio-volume-low.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 192 192">
-  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#000;fill-opacity:0.5;stroke:#000;stroke-width:6;">
+  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#959595;stroke:#000;stroke-width:6;">
   	<path d="m 96,40 0,116 -50,-40 -20,0 0,-36 20,0 z"/>
   	<g transform="rotate(45,96,96)">
-  	  <path style="fill:none;" d="m 96,80 a 20,20 0 0 1 20,20"/>
+  	  <path style="fill:none;stroke:#007B00;stroke-width:12;" d="m 96,80 a 20,20 0 0 1 20,20"/>
   	</g>
   </g>
 </svg>

--- a/icons/audio-volume-medium.svg
+++ b/icons/audio-volume-medium.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 192 192">
-  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#000;fill-opacity:0.5;stroke:#000;stroke-width:6;">
+  <g style="stroke-linecap:round;stroke-linejoin:round;fill:#959595;stroke:#000;stroke-width:6;">
   	<path d="m 96,40 0,116 -50,-40 -20,0 0,-36 20,0 z"/>
   	<g transform="rotate(45,96,96)">
-  	  <path style="fill:none;" d="m 96,80 a 20,20 0 0 1 20,20 m -20,-40 a 40,40 0 0 1 40,40"/>
+  	  <path style="fill:none;stroke:#007B00;stroke-width:12;" d="m 96,80 a 20,20 0 0 1 20,20 m -20,-40 a 40,40 0 0 1 40,40"/>
   	</g>
   </g>
 </svg>

--- a/icons/audio-volume-muted.svg
+++ b/icons/audio-volume-muted.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 192 192">
   <g style="stroke-linecap:round;stroke-linejoin:round;">
-  	<path style="fill:#000;fill-opacity:0.5;stroke:#000;stroke-width:6;" d="m 96,40 0,116 -50,-40 -20,0 0,-36 20,0 z"/> 
-    <path style="fill:none;stroke:#BF3603;stroke-width:7" d="m 156,40 -116,116"/>
+  	<path style="fill:#959595;stroke:#000;stroke-width:6;" d="m 96,40 0,116 -50,-40 -20,0 0,-36 20,0 z"/> 
+    <path style="fill:none;stroke:#007B00;stroke:#BF3603;stroke-width:7" d="m 156,40 -116,116"/>
   </g>
 </svg>


### PR DESCRIPTION
See puppylinux-woof-CE/puppy_icon_theme#16 and puppylinux-woof-CE/woof-CE#3811.

I'm not sure about this one because the three curves are very small so it's not just the contrast, especially at 16x16.

With 2x stroke width it's better:

![pmat](https://user-images.githubusercontent.com/1471149/210970400-4580bce6-7591-47d1-bada-ba2150c662c9.png)

